### PR TITLE
Fix mobile race results display to properly show all boat data

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
             text-decoration: underline;
         }
 
-        /* Mobile-first responsive design for race results */
+        /* Improved mobile responsive design for race results */
         @media (max-width: 768px) {
             .header h1 {
                 font-size: 2rem;
@@ -196,92 +196,68 @@
                 padding: 15px;
             }
             
-            /* Hide the traditional table on mobile */
+            /* Make table more mobile-friendly instead of hiding it */
             .results-table {
-                display: none;
+                font-size: 0.8rem;
+                display: block;
+                overflow-x: auto;
+                white-space: nowrap;
             }
             
-            /* Show mobile card layout instead */
-            .mobile-results {
+            .results-table thead,
+            .results-table tbody,
+            .results-table th,
+            .results-table td,
+            .results-table tr {
                 display: block;
+            }
+            
+            .results-table thead tr {
+                position: absolute;
+                top: -9999px;
+                left: -9999px;
+            }
+            
+            .results-table tr {
+                background: rgba(52, 73, 94, 0.9);
+                border: 1px solid rgba(231, 76, 60, 0.3);
+                border-radius: 10px;
+                padding: 15px;
+                margin-bottom: 15px;
+                position: relative;
+            }
+            
+            .results-table tr.place-1 { background: rgba(231, 76, 60, 0.2); }
+            .results-table tr.place-2 { background: rgba(149, 165, 166, 0.2); }
+            .results-table tr.place-3 { background: rgba(241, 196, 15, 0.2); }
+            
+            .results-table td {
+                border: none;
+                position: relative;
+                padding: 8px 0 8px 45%;
+                text-align: left;
+                white-space: normal;
+            }
+            
+            .results-table td:before {
+                content: attr(data-label);
+                position: absolute;
+                left: 6px;
+                width: 40%;
+                padding-right: 10px;
+                white-space: nowrap;
+                text-align: left;
+                font-weight: bold;
+                color: #bdc3c7;
+            }
+            
+            /* Hide mobile card layout on mobile - we're improving the table instead */
+            .mobile-results {
+                display: none;
             }
         }
         
-        /* Mobile card layout (hidden on desktop) */
-        .mobile-results {
-            display: none;
-        }
-        
-        .result-card {
-            background: rgba(52, 73, 94, 0.9);
-            border-radius: 10px;
-            padding: 20px;
-            margin-bottom: 15px;
-            border-left: 4px solid #e74c3c;
-            color: #ecf0f1;
-            box-shadow: 0 4px 15px rgba(0,0,0,0.4);
-        }
-        
-        .result-card.place-1 {
-            background: rgba(231, 76, 60, 0.2);
-            border-left-color: #e74c3c;
-        }
-        
-        .result-card.place-2 {
-            background: rgba(149, 165, 166, 0.2);
-            border-left-color: #95a5a6;
-        }
-        
-        .result-card.place-3 {
-            background: rgba(241, 196, 15, 0.2);
-            border-left-color: #f1c40f;
-        }
-        
-        .card-position {
-            font-size: 2rem;
-            font-weight: bold;
-            color: #e74c3c;
-            margin-bottom: 10px;
-        }
-        
-        .card-boat-name {
-            font-size: 1.5rem;
-            font-weight: bold;
-            margin-bottom: 8px;
-            color: #ecf0f1;
-        }
-        
-        .card-detail {
-            display: flex;
-            justify-content: space-between;
-            margin: 5px 0;
-            font-size: 1rem;
-        }
-        
-        .card-label {
-            color: #bdc3c7;
-            font-weight: 500;
-        }
-        
-        .card-value {
-            color: #ecf0f1;
-            font-weight: 600;
-        }
-        
-        .card-time {
-            background: rgba(52, 152, 219, 0.2);
-            padding: 8px 12px;
-            border-radius: 5px;
-            margin-top: 10px;
-            text-align: center;
-            border: 1px solid rgba(52, 152, 219, 0.3);
-        }
-        
-        .card-adjusted-time {
-            font-size: 1.2rem;
-            font-weight: bold;
-            color: #3498db;
-        }
+
     </style>
 </head>
 <body>
@@ -395,12 +371,12 @@
                 
                 html += `
                     <tr class="${rowClass}">
-                        <td><strong>${positionIcon} ${boat.position}</strong></td>
-                        <td>${boat.name}</td>
-                        <td>${boat.skipper || ''}</td>
-                        <td>${boat.phrf}</td>
-                        <td>${boat.finishTime}</td>
-                        <td><strong>${boat.adjustedTime}</strong></td>
+                        <td data-label="🏆 Position"><strong>${positionIcon} ${boat.position}</strong></td>
+                        <td data-label="⛵ Boat Name">${boat.name}</td>
+                        <td data-label="👨‍✈️ Skipper">${boat.skipper || ''}</td>
+                        <td data-label="📊 PHRF Rating">${boat.phrf}</td>
+                        <td data-label="⏱️ Finish Time">${boat.finishTime}</td>
+                        <td data-label="🎯 Adjusted Time"><strong>${boat.adjustedTime}</strong></td>
                     </tr>
                 `;
             });
@@ -408,41 +384,6 @@
             html += `
                     </tbody>
                 </table>
-                
-                <!-- Mobile-friendly card layout -->
-                <div class="mobile-results">
-            `;
-            
-            raceData.boats.forEach(boat => {
-                const cardClass = boat.position <= 3 ? `place-${boat.position}` : '';
-                const positionIcon = boat.position === 1 ? '🥇' : boat.position === 2 ? '🥈' : boat.position === 3 ? '🥉' : '';
-                
-                html += `
-                    <div class="result-card ${cardClass}">
-                        <div class="card-position">${positionIcon} Position ${boat.position}</div>
-                        <div class="card-boat-name">${boat.name}</div>
-                        ${boat.skipper ? `<div class="card-detail">
-                            <span class="card-label">👨‍✈️ Skipper:</span>
-                            <span class="card-value">${boat.skipper}</span>
-                        </div>` : ''}
-                        <div class="card-detail">
-                            <span class="card-label">📊 PHRF Rating:</span>
-                            <span class="card-value">${boat.phrf}</span>
-                        </div>
-                        <div class="card-detail">
-                            <span class="card-label">⏱️ Finish Time:</span>
-                            <span class="card-value">${boat.finishTime}</span>
-                        </div>
-                        <div class="card-time">
-                            <div class="card-label">🎯 Adjusted Time</div>
-                            <div class="card-adjusted-time">${boat.adjustedTime}</div>
-                        </div>
-                    </div>
-                `;
-            });
-            
-            html += `
-                </div>
             `;
             
             resultsContainer.innerHTML = html;


### PR DESCRIPTION
- Remove broken card-based mobile layout that wasn't showing boat results
- Implement improved mobile table design that transforms table into card-like format
- Add data-label attributes to table cells for mobile field labels
- Use CSS to hide table headers on mobile and show labels inline with data
- Style mobile table rows as individual cards with proper spacing and colors
- Maintain position-based color coding (1st, 2nd, 3rd place) on mobile
- Ensure all race data (position, boat name, skipper, PHRF, times) is visible on mobile
- Keep desktop table layout unchanged while greatly improving mobile experience


Change-ID: sa0ee84fda796750dk