### PR TITLE
Fix mobile table alignment between field labels and data

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,7 +234,7 @@
             .results-table td {
                 border: none;
                 position: relative;
-                padding: 8px 0 8px 45%;
+                padding: 8px 10px 8px 50%;
                 text-align: left;
                 white-space: normal;
             }
@@ -242,8 +242,8 @@
             .results-table td:before {
                 content: attr(data-label);
                 position: absolute;
-                left: 6px;
-                width: 40%;
+                left: 10px;
+                width: 45%;
                 padding-right: 10px;
                 white-space: nowrap;
                 text-align: left;


### PR DESCRIPTION
- Adjust mobile table CSS to properly align field labels and values
- Increase label width to 45% and data padding to 50% for clean separation
- Add consistent 10px padding for both labels and data
- Ensure proper spacing and alignment in mobile card-style table layout


Change-ID: s575fac7060d0af69k